### PR TITLE
optimize layoutSubviews: method in HRColorPickerView

### DIFF
--- a/ColorPicker/HRColorPickerView.m
+++ b/ColorPicker/HRColorPickerView.m
@@ -203,11 +203,27 @@ typedef struct timeval timeval;
     }
 
     CGFloat headerHeight = (20 + 44) * 1.625;
-    self.colorMapView.frame = CGRectMake(
-            0, headerHeight,
-            CGRectGetWidth(self.frame),
-            MAX(CGRectGetWidth(self.frame), CGRectGetHeight(self.frame) - headerHeight)
-    );
+    
+    self.colorInfoView.frame = CGRectMake(8, (headerHeight - 84) / 2.0f, 66, 84);
+    
+    CGFloat hexLabelHeight = 18;
+    CGFloat sliderHeight = 11;
+    CGFloat brightnessPickerTop = CGRectGetMaxY(self.colorInfoView.frame) - hexLabelHeight - sliderHeight;
+    
+    CGRect brightnessPickerFrame = CGRectMake(
+                                              CGRectGetMaxX(self.colorInfoView.frame) + 9,
+                                              brightnessPickerTop,
+                                              CGRectGetWidth(self.frame) - CGRectGetMaxX(self.colorInfoView.frame) - 9 * 2,
+                                              sliderHeight);
+    
+    self.brightnessSlider.frame = [self.brightnessSlider frameForAlignmentRect:brightnessPickerFrame];
+    
+    CGFloat mapHeight = self.bounds.size.height - MAX(CGRectGetMaxY(self.brightnessSlider.frame), CGRectGetMaxY(self.colorInfoView.frame)) - 8;
+    self.colorMapView.frame = CGRectMake(0,
+                                         self.bounds.size.height - mapHeight,
+                                         CGRectGetWidth(self.frame),
+                                         MAX(0, mapHeight));
+    
     // use intrinsicContentSize for 3.5inch screen
     CGRect colorMapFrame = (CGRect) {
             .origin = CGPointZero,
@@ -217,19 +233,6 @@ typedef struct timeval timeval;
     self.colorMapView.frame = colorMapFrame;
     headerHeight = CGRectGetMinY(colorMapFrame);
 
-    self.colorInfoView.frame = CGRectMake(8, (headerHeight - 84) / 2.0f, 66, 84);
-
-    CGFloat hexLabelHeight = 18;
-    CGFloat sliderHeight = 11;
-    CGFloat brightnessPickerTop = CGRectGetMaxY(self.colorInfoView.frame) - hexLabelHeight - sliderHeight;
-
-    CGRect brightnessPickerFrame = CGRectMake(
-            CGRectGetMaxX(self.colorInfoView.frame) + 9,
-            brightnessPickerTop,
-            CGRectGetWidth(self.frame) - CGRectGetMaxX(self.colorInfoView.frame) - 9 * 2,
-            sliderHeight);
-
-    self.brightnessSlider.frame = [self.brightnessSlider frameForAlignmentRect:brightnessPickerFrame];
 }
 
 @end

--- a/Project/Hayashi311ColorPickerSample/HRSampleRootTableViewController.m
+++ b/Project/Hayashi311ColorPickerSample/HRSampleRootTableViewController.m
@@ -27,6 +27,7 @@
 
 #import "HRSampleRootTableViewController.h"
 #import "HRSampleColorPickerViewController2.h"
+#import "HRColorPickerView.h"
 
 @interface HRSampleRootTableViewController ()
 
@@ -75,6 +76,17 @@
                                              animated:YES];
         return;
 
+    }
+    else if(indexPath.row == 6){
+        UIViewController* c = [[UIViewController alloc]init];
+        c.view.frame = CGRectMake(0, 0, 320, 500);
+        c.view.backgroundColor = self.view.backgroundColor;
+        HRColorPickerView* view = [[HRColorPickerView alloc]initWithFrame:CGRectMake(0, 0, 200, 250)];
+        view.center = CGPointMake(c.view.bounds.size.width/2, c.view.bounds.size.height/2);
+        view.backgroundColor = [UIColor colorWithRed:(float)0xcc/0xff green:(float)0xdd/0xff blue:(float)0xff/0xff alpha:1];
+        [view setColor:[UIColor brownColor]];
+        [c.view addSubview:view];
+        [self.navigationController pushViewController:c animated:YES];
     }
 }
 

--- a/Project/Hayashi311ColorPickerSample/Main.storyboard
+++ b/Project/Hayashi311ColorPickerSample/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="TQD-yp-f8W">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="TQD-yp-f8W">
     <dependencies>
-        <deployment defaultVersion="1792" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <scenes>
-        <!--Sample Root Table View Controller - HRColorPicker by hayashi311-->
+        <!--HRColorPicker by hayashi311-->
         <scene sceneID="Kkp-Bx-O7S">
             <objects>
                 <tableViewController id="6GW-io-gwo" customClass="HRSampleRootTableViewController" sceneMemberID="viewController">
@@ -130,6 +130,23 @@
                                             <segue destination="NPW-f7-MGO" kind="push" id="R7C-VN-9iK"/>
                                         </connections>
                                     </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="ISl-EX-a1J" style="IBUITableViewCellStyleDefault" id="NQJ-mD-xmN">
+                                        <rect key="frame" x="0.0" y="394" width="320" height="66"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NQJ-mD-xmN" id="aQP-AU-e2w">
+                                            <rect key="frame" x="0.0" y="0.0" width="287" height="65"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Just view" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ISl-EX-a1J">
+                                                    <rect key="frame" x="15" y="0.0" width="270" height="65"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -162,7 +179,6 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pwg-8M-Eu2" customClass="HRColorPickerView">
                                 <rect key="frame" x="0.0" y="64" width="320" height="504"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                             </view>
                         </subviews>
@@ -197,11 +213,9 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="v0V-0H-PQL" customClass="HRColorPickerView">
                                 <rect key="frame" x="0.0" y="64" width="320" height="504"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xjh-OR-WLh" customClass="HRColorInfoView">
                                         <rect key="frame" x="8" y="10" width="66" height="84"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="84" id="dBc-JS-2SR"/>
@@ -210,7 +224,6 @@
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Sys-iB-e21" customClass="HRBrightnessSlider">
                                         <rect key="frame" x="83" y="65" width="228" height="11"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" red="0.66666666666666663" green="0.61911003492255423" blue="0.62945342689079642" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="11" id="7el-yA-m3x"/>
@@ -223,7 +236,6 @@
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lot-0L-K9C" customClass="HRColorMapView">
                                         <rect key="frame" x="0.0" y="104" width="320" height="400"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="saturationUpperLimit">
@@ -236,7 +248,6 @@
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hKb-Ei-PQU">
                                         <rect key="frame" x="0.0" y="0.0" width="100" height="10"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="100" id="AXh-O4-Oq5"/>
@@ -244,7 +255,6 @@
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3mt-dQ-rvI">
                                         <rect key="frame" x="0.0" y="94" width="100" height="10"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="100" id="6hf-Fw-Igs"/>
@@ -307,11 +317,9 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xJc-qD-6Pf" customClass="HRColorPickerView">
                                 <rect key="frame" x="0.0" y="64" width="320" height="504"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zdG-uo-2OT" customClass="HRColorInfoView">
                                         <rect key="frame" x="8" y="10" width="66" height="84"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="84" id="Piq-8W-XBp"/>
@@ -320,7 +328,6 @@
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qqv-Ra-SEr" customClass="HRBrightnessSlider">
                                         <rect key="frame" x="83" y="65" width="228" height="11"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" red="0.66666666669999997" green="0.61911003490000005" blue="0.62945342689999995" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="11" id="9Mz-vL-KH4"/>
@@ -333,7 +340,6 @@
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="puP-wT-2uj" customClass="HRColorMapView">
                                         <rect key="frame" x="0.0" y="104" width="320" height="400"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="saturationUpperLimit">
@@ -346,7 +352,6 @@
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WW5-DT-Ps6">
                                         <rect key="frame" x="0.0" y="0.0" width="100" height="10"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="100" id="FmR-Mf-RUC"/>
@@ -354,7 +359,6 @@
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vmc-nn-GOY">
                                         <rect key="frame" x="0.0" y="94" width="100" height="10"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="100" id="AFh-ny-KAQ"/>
@@ -422,11 +426,9 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GW3-dt-B4w" customClass="HRColorPickerView">
                                 <rect key="frame" x="0.0" y="64" width="320" height="504"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lOZ-ak-faU" customClass="HRBrightnessSlider">
                                         <rect key="frame" x="9" y="149" width="302" height="11"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" red="0.66666666669999997" green="0.61911003490000005" blue="0.62945342689999995" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="11" id="ceW-sY-Pdn"/>
@@ -439,7 +441,6 @@
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KK3-np-Uhc" customClass="HRColorMapView">
                                         <rect key="frame" x="0.0" y="180" width="320" height="324"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="saturationUpperLimit">
@@ -452,7 +453,6 @@
                                     </view>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Y6N-Au-ZtW">
                                         <rect key="frame" x="20" y="65" width="123" height="29"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <segments>
                                             <segment title="First"/>
                                             <segment title="Second"/>
@@ -460,7 +460,6 @@
                                     </segmentedControl>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lhr-HY-9Lv">
                                         <rect key="frame" x="230" y="65" width="46" height="30"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Button">
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>


### PR DESCRIPTION
add show "Just view" cell in example, that show the way to show a color picker view in a controler, instead of pushing a color picker controller